### PR TITLE
chore: fixed "typo" in download links in README. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Easily calculate the missing number in a ratio. Given the equation **2/4=?/10**,
 
 <img src="art/example.gif" width="640">
 
-**[Download it!](https://github.com/matthewmcvickar/alfred-ratio-calculator/releases/download/v1.0/Ratio.Calculator.alfredworkflow)**
+**[Download it!](https://github.com/matthewmcvickar/alfred-ratio-calculator/releases/download/v1.0/RatioCalculator.alfredworkflow)**
 
 ## Installation
 
-1. **[Download the workflow.](https://github.com/matthewmcvickar/alfred-ratio-calculator/releases/download/v1.0/Ratio.Calculator.alfredworkflow)**
+1. **[Download the workflow.](https://github.com/matthewmcvickar/alfred-ratio-calculator/releases/download/v1.0/RatioCalculator.alfredworkflow)**
 
 2. Double-click on the **Ratio Calculator.alfredworkflow** file you just downloaded to add it to Alfred.
 


### PR DESCRIPTION
Download links were not linked correctly - I think Github updated something where a file with spaces used to be a `.` and now the space just gets removed.
